### PR TITLE
ignore case of mac addresses

### DIFF
--- a/scanner/pamela-scanner.sh
+++ b/scanner/pamela-scanner.sh
@@ -150,7 +150,7 @@ function translate {
     FS=","
     while ((getline nl < names) > 0) { 
       split(nl, n); 
-      nms[n[1]] = n[2]
+      nms[tolower(n[1])] = n[2]
     }
     close(names)
     RS=","
@@ -160,7 +160,7 @@ function translate {
       #print "input:", i, "translates to", (i in nms?nms[i]:i)
       if (!first) 
         printf(",")
-      printf (i in nms?nms[i]:i)
+      printf (tolower(i) in nms?nms[tolower(i)]:i)
       first=0
     }
   }')


### PR DESCRIPTION
I spent quite some time debugging the script until I noticed that I had the MACs in uppercase in my translation file (copied from the UI of my router) and arp-scan returns the MACs in lowercase.

Making sure that MACs are always compared in lowercase may save somebody some time in the future.